### PR TITLE
fix(sequences): prevent accessing stepResults before being finalized

### DIFF
--- a/src/sequence.test.ts
+++ b/src/sequence.test.ts
@@ -65,11 +65,11 @@ describe('SeqChecker', () => {
   const processMsgs = (seq: FBSequence, msgs: ViewableDltMsg[]): FbSequenceResult => {
     const seqResult = newFbSeqResult(seq)
     const seqChecker = new SeqChecker(seq, seqResult, DltFilter)
-    seqChecker.processMsgs(
-      msgs.map((m, idx) => {
-        return { ...m, index: idx + 1 }
-      }),
-    )
+    const idxedMsgs = msgs.map((m, idx) => {
+      return { ...m, index: idx + 1 }
+    })
+    seqChecker.processMsgs(idxedMsgs)
+
     return seqResult
   }
 
@@ -478,6 +478,10 @@ describe('SeqChecker', () => {
     // now test with alt-sequence with ignoreOutOfOrder:
     testSeq([{ ignoreOutOfOrder: true, alt: [s1, s2] }, s3, s4], [m2, m3, m4, m1, m3, m4], ['ok', 'ok'])
     testSeq([{ ignoreOutOfOrder: true, alt: [s1, s2] }, s3, s4], [m2, m3, m4, m3, m1, m4], ['ok', 'error'])
+
+    // error cases reported with v0.10.0: (Cannot read properties of undefined (reading 'stepType'))
+    testSeq([s1, { par: [s2] }, { ...s3, canCreateNew: false }], [m2, m3, m3], ['error']) // that one is ok
+    testSeq([s1, { par: [s2] }, { ...s3, canCreateNew: false }, s4], [m2, m3, m3], ['error']) // that one did fails on v0.10.0
   })
 })
 

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -457,7 +457,6 @@ export interface FBSeqStep {
    *
    * @remarks can not be used if:
    * - the previous step is optional.
-   * - (TODO???) should not be used on the single parallel steps but on the parallel step itself.
    */
   ignoreOutOfOrder?: boolean
 }
@@ -983,9 +982,8 @@ class SeqOccurrence<DltFilterType extends IDltFilter> {
     // if any failure -> error
     // otherwise "max" of all steps. per step:
     // error, warning, undefined, ok
-    if (this.failures.length > 0) {
-      return 'error'
-    }
+
+    // but first we do need to finalize the results of the steps
     const stepResults = this.steps.map((step) => {
       step.finalizeResults()
       const result = this.stepsResult.get(step)
@@ -1004,6 +1002,10 @@ class SeqOccurrence<DltFilterType extends IDltFilter> {
         return acc
       }, 'ok')
     })
+
+    if (this.failures.length > 0) {
+      return 'error'
+    }
 
     if (stepResults.includes('error')) {
       return 'error'


### PR DESCRIPTION
result() was not finalizing each steps results leading to undefined values for steps that need finalization (par).
This happened only if the occurrence ended with a failure.

Added two test cases to avoid in future as well.