### PR TITLE
fix(sequences): escape using the html notation

### DIFF
--- a/src/sequence.test.ts
+++ b/src/sequence.test.ts
@@ -505,12 +505,12 @@ describe('escapeForMD', () => {
     const str = 'this is a *test* _string_ with `special` chars \\ * _ {} [] <> () # + - . !| &'
     const escaped = escapeForMD(str)
     expect(escaped).to.equal(
-      'this is a \\*test\\* \\_string\\_ with \\`special\\` chars \\\\ \\* \\_ \\{\\} \\[\\] &lt;&gt; \\(\\) \\# \\+ \\- \\. \\!\\| &amp;',
+      'this is a &#42;test&#42; &#95;string&#95; with &#96;special&#96; chars &#92; &#42; &#95; &#123;&#125; &#91;&#93; &lt;&gt; &#40;&#41; &#35; &#43; &#45; &#46; &#33;&#124; &amp;',
     )
   })
   it('should not escape non markdown special chars', () => {
-    const str = '[10,03,FFFF-FFFF]'
+    const str = '[10,03,FFFF-FFFF]' // , should not be escaped
     const escaped = escapeForMD(str)
-    expect(escaped).to.equal('\\[10,03,FFFF\\-FFFF\\]')
+    expect(escaped).to.equal('&#91;10,03,FFFF&#45;FFFF&#93;')
   })
 })

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -673,7 +673,7 @@ const asCollapsable = (summary: string, content: string): Html => {
 /**
  * Escape a text for usage in markdown and html
  * @param text - to be escaped for usage in markdown and html
- * @returns text with escaped characters
+ * @returns text with escaped characters using the &#...; notation
  */
 
 export const escapeForMD = (text: string): string => {
@@ -684,24 +684,24 @@ export const escapeForMD = (text: string): string => {
     /[\\\`*_{}\[\]<>()#\+\-\.!|&]/g,
     (match) =>
       ({
-        '\\': '\\\\',
-        '`': '\\`',
-        '*': '\\*',
-        _: '\\_',
-        '{': '\\{',
-        '}': '\\}',
-        '[': '\\[',
-        ']': '\\]',
+        '\\': '&#92;',
+        '`': '&#96;',
+        '*': '&#42;',
+        _: '&#95;',
+        '{': '&#123;',
+        '}': '&#125;',
+        '[': '&#91;',
+        ']': '&#93;',
         '<': '&lt;', // we use that to escape html as well
         '>': '&gt;', // we use that to escape html as well
-        '(': '\\(',
-        ')': '\\)',
-        '#': '\\#',
-        '+': '\\+',
-        '-': '\\-',
-        '.': '\\.',
-        '!': '\\!',
-        '|': '\\|',
+        '(': '&#40;',
+        ')': '&#41;',
+        '#': '&#35;',
+        '+': '&#43;',
+        '-': '&#45;',
+        '.': '&#46;',
+        '!': '&#33;',
+        '|': '&#124;', // this works in markdown tables as well
         '&': '&amp;', // would not be needed in markdown but we use it for html as well
       }[match]),
   )


### PR DESCRIPTION
That works in both markdown and html code.
Otherwise plenty of escaped chars read wrongly in html e.g. foo\_bar instead of foo_bar.