### PR TITLE
fix(tl): $ being part of the color

### DIFF
--- a/src/timeline.test.ts
+++ b/src/timeline.test.ts
@@ -95,6 +95,11 @@ describe('TL', () => {
       expect(tl.calculateY()).to.equal('value1|tooltip1|color1|$')
     })
 
+    it('should return the value string with tooltip, color and persistLcs', () => {
+      const tl = new TL('group1', 'lane1', 'value1', { tooltip: 'tooltip1', color: 'color1', persistLcs: true })
+      expect(tl.calculateY()).to.equal('value1|tooltip1|color1|$') // persistLcs needs to be | prepended anyhow!
+    })
+
     it('should return the value string with tooltip and color', () => {
       const tl = new TL('group1', 'lane1', 'value1', { tooltip: 'tooltip1', color: 'color1' })
       expect(tl.calculateY()).to.equal('value1|tooltip1|color1')

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -65,7 +65,7 @@ export class TL {
     if (this.tooltip || this.color || this.tlEnds || this.persistLcs) {
       return `${valueStr}|${this.tooltip ? this.tooltip.replaceAll('|', ' ') : ''}${this.color ? '|' + this.color : ''}${
         this.tlEnds ? '|' : ''
-      }${this.persistLcs ? '$' : ''}`
+      }${this.persistLcs ? (this.tlEnds || !this.color ? '$' : '|$') : ''}`
     } else {
       return this.value !== undefined ? (typeof this.value === 'number' ? this.value : valueStr) : undefined
     }


### PR DESCRIPTION
if persistLcs is used the $ needs to be prepended with the | to avoid treated as part of the color